### PR TITLE
Add Stripe subscription flow with Get Plus page

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -9,6 +9,7 @@ import { Chat } from '@/pages/Chat';
 import { NotFound } from '@/pages/NotFound';
 import { SubscribeSuccess } from '@/pages/SubscribeSuccess';
 import { SubscribeCancel } from '@/pages/SubscribeCancel';
+import { Subscribe } from '@/pages/Subscribe';
 import { useAuthStore } from '@/stores/authStore';
 
 function App() {
@@ -36,6 +37,7 @@ function App() {
             <Route path="meds" element={<Medications />} />
             <Route path="meds/new" element={<AddMedication />} />
             <Route path="chat" element={<Chat />} />
+            <Route path="subscribe" element={<Subscribe />} />
             <Route path="subscribe/success" element={<SubscribeSuccess />} />
             <Route path="subscribe/cancel" element={<SubscribeCancel />} />
           </Route>

--- a/project/src/components/layout/Navbar.tsx
+++ b/project/src/components/layout/Navbar.tsx
@@ -45,6 +45,14 @@ export function Navbar() {
               >
                 AI Chat
               </Link>
+              {user?.plan !== 'plus' && (
+                <Link
+                  to="/subscribe"
+                  className="px-3 py-2 rounded-md text-sm font-medium text-white bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 transition-colors"
+                >
+                  Get Plus
+                </Link>
+              )}
             </nav>
 
             <DropdownMenu>

--- a/project/src/pages/Chat.tsx
+++ b/project/src/pages/Chat.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -10,7 +11,7 @@ interface Message {
 }
 
 export function Chat() {
-  const { user, upgradeToPlus } = useAuthStore();
+  const { user } = useAuthStore();
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
 
@@ -28,7 +29,9 @@ export function Chat() {
             <p className="text-center text-gray-700">
               This feature is available for Plus subscribers.
             </p>
-            <Button onClick={() => upgradeToPlus()}>Upgrade to Plus</Button>
+            <Button asChild>
+              <Link to="/subscribe">Upgrade to Plus</Link>
+            </Button>
           </CardContent>
         </Card>
       </div>

--- a/project/src/pages/Subscribe.tsx
+++ b/project/src/pages/Subscribe.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/stores/authStore';
+
+export function Subscribe() {
+  const { upgradeToPlus } = useAuthStore();
+
+  return (
+    <div className="space-y-8">
+      <div className="text-center py-16 rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 text-white">
+        <h1 className="text-4xl font-bold mb-2">Get Plus</h1>
+        <p className="text-lg">Unlock AI chat and premium features</p>
+      </div>
+      <Card className="max-w-md mx-auto shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-center">Plus Plan</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-center">
+          <p className="text-gray-700">
+            Access to AI Assistant chat and future premium updates.
+          </p>
+          <Button
+            className="bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:from-blue-700 hover:to-purple-700"
+            onClick={() => upgradeToPlus()}
+          >
+            Subscribe for $9.99/month
+          </Button>
+          <p className="text-xs text-gray-500">Payments processed securely with Stripe.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add "Get Plus" link to navbar for upgrading
- create subscription page with Stripe checkout and gradient styling
- wire up routing and chat page to new subscribe page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688e9a6860e08333afad2f364dd061c5