### PR TITLE
feat: add plan comparison and golden subscribe button

### DIFF
--- a/project/src/components/layout/Navbar.tsx
+++ b/project/src/components/layout/Navbar.tsx
@@ -46,12 +46,13 @@ export function Navbar() {
                 AI Chat
               </Link>
               {user?.plan !== 'plus' && (
-                <Link
-                  to="/subscribe"
-                  className="px-3 py-2 rounded-md text-sm font-medium text-white bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 transition-colors"
+                <Button
+                  asChild
+                  size="sm"
+                  className="bg-gradient-to-r from-yellow-400 to-yellow-600 text-white hover:from-yellow-500 hover:to-yellow-700"
                 >
-                  Get Plus
-                </Link>
+                  <Link to="/subscribe">Get Plus</Link>
+                </Button>
               )}
             </nav>
 

--- a/project/src/pages/Subscribe.tsx
+++ b/project/src/pages/Subscribe.tsx
@@ -8,26 +8,36 @@ export function Subscribe() {
   return (
     <div className="space-y-8">
       <div className="text-center py-16 rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 text-white">
-        <h1 className="text-4xl font-bold mb-2">Get Plus</h1>
-        <p className="text-lg">Unlock AI chat and premium features</p>
+        <h1 className="text-4xl font-bold mb-2">Choose Your Plan</h1>
+        <p className="text-lg">Compare Free and Plus options</p>
       </div>
-      <Card className="max-w-md mx-auto shadow-lg">
-        <CardHeader>
-          <CardTitle className="text-center">Plus Plan</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4 text-center">
-          <p className="text-gray-700">
-            Access to AI Assistant chat and future premium updates.
-          </p>
-          <Button
-            className="bg-gradient-to-r from-blue-600 to-purple-600 text-white hover:from-blue-700 hover:to-purple-700"
-            onClick={() => upgradeToPlus()}
-          >
-            Subscribe for $9.99/month
-          </Button>
-          <p className="text-xs text-gray-500">Payments processed securely with Stripe.</p>
-        </CardContent>
-      </Card>
+      <div className="max-w-4xl mx-auto grid gap-8 md:grid-cols-2">
+        <Card className="shadow-lg flex flex-col">
+          <CardHeader>
+            <CardTitle className="text-center">Free Plan</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-center flex-1 flex flex-col">
+            <p className="text-gray-700 flex-1">Basic medication management features.</p>
+            <p className="text-2xl font-bold">$0</p>
+          </CardContent>
+        </Card>
+        <Card className="shadow-lg bg-gradient-to-br from-yellow-400 via-yellow-500 to-yellow-600 text-white flex flex-col">
+          <CardHeader>
+            <CardTitle className="text-center">Plus Plan</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-center flex-1 flex flex-col">
+            <p className="flex-1">Access to AI Assistant chat and future premium updates.</p>
+            <Button
+              size="sm"
+              className="bg-white text-yellow-700 hover:bg-gray-100"
+              onClick={() => upgradeToPlus()}
+            >
+              Subscribe for $9.99/month
+            </Button>
+            <p className="text-xs text-white/80">Payments processed securely with Stripe.</p>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style navbar's Get Plus button with a golden gradient matching profile button size
- add side-by-side Free vs Plus plan comparison with colorful Plus card and Stripe checkout link

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ea1a9d90c8333b28afdc88910f993