### PR TITLE
Increase plan card height and update Plus flow

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -1,0 +1,21 @@
+# MediMatch
+
+This project includes a React frontend and a minimal Node.js backend that uses Stripe Checkout for Plus plan subscriptions.
+
+## Running the backend
+
+1. Install dependencies with `npm install`.
+2. Set the environment variables `STRIPE_SECRET_KEY` and `STRIPE_PRICE_ID`.
+3. From the project root, start the server:
+
+   ```bash
+   node server/index.js
+   ```
+
+The server exposes `/api/create-checkout-session` which returns a Stripe Checkout URL used by the frontend when upgrading to Plus.
+
+## Development
+
+- `npm run dev` – start Vite dev server
+- `npm run lint` – run ESLint
+- `npm run build` – type-check and build the production bundle

--- a/project/server/index.js
+++ b/project/server/index.js
@@ -1,9 +1,20 @@
 import http from 'http';
 
+/**
+ * Minimal HTTP server used by the frontend to initiate Stripe Checkout.
+ * Expects the following environment variables:
+ *  - STRIPE_SECRET_KEY: secret API key from Stripe dashboard
+ *  - STRIPE_PRICE_ID: price identifier for the Plus subscription
+ *  - CLIENT_URL: base URL of the frontend application
+ */
 const PORT = process.env.PORT || 3000;
-const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder';
-const PRICE_ID = process.env.STRIPE_PRICE_ID || 'price_placeholder';
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+const PRICE_ID = process.env.STRIPE_PRICE_ID;
 const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173';
+
+if (!STRIPE_SECRET_KEY || !PRICE_ID) {
+  throw new Error('Stripe configuration is missing. Set STRIPE_SECRET_KEY and STRIPE_PRICE_ID.');
+}
 
 const server = http.createServer(async (req, res) => {
   if (req.method === 'POST' && req.url === '/api/create-checkout-session') {

--- a/project/src/components/layout/Navbar.tsx
+++ b/project/src/components/layout/Navbar.tsx
@@ -10,7 +10,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { Pill, User, LogOut } from 'lucide-react';
 
 export function Navbar() {
-  const { user, logout } = useAuthStore();
+  const { user, logout, upgradeToPlus } = useAuthStore();
   const navigate = useNavigate();
 
   const handleLogout = () => {
@@ -47,11 +47,11 @@ export function Navbar() {
               </Link>
               {user?.plan !== 'plus' && (
                 <Button
-                  asChild
                   size="sm"
-                  className="bg-gradient-to-r from-yellow-400 to-yellow-600 text-white hover:from-yellow-500 hover:to-yellow-700"
+                  className="bg-gradient-to-r from-blue-500 to-purple-600 text-white hover:from-blue-600 hover:to-purple-700"
+                  onClick={upgradeToPlus}
                 >
-                  <Link to="/subscribe">Get Plus</Link>
+                  Get Plus
                 </Button>
               )}
             </nav>

--- a/project/src/pages/Chat.tsx
+++ b/project/src/pages/Chat.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -11,7 +10,7 @@ interface Message {
 }
 
 export function Chat() {
-  const { user } = useAuthStore();
+  const { user, upgradeToPlus } = useAuthStore();
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
 
@@ -29,9 +28,7 @@ export function Chat() {
             <p className="text-center text-gray-700">
               This feature is available for Plus subscribers.
             </p>
-            <Button asChild>
-              <Link to="/subscribe">Upgrade to Plus</Link>
-            </Button>
+            <Button onClick={upgradeToPlus}>Upgrade to Plus</Button>
           </CardContent>
         </Card>
       </div>

--- a/project/src/pages/Subscribe.tsx
+++ b/project/src/pages/Subscribe.tsx
@@ -12,7 +12,7 @@ export function Subscribe() {
         <p className="text-lg">Compare Free and Plus options</p>
       </div>
       <div className="max-w-4xl mx-auto grid gap-8 md:grid-cols-2">
-        <Card className="shadow-lg flex flex-col">
+        <Card className="shadow-lg flex flex-col h-96">
           <CardHeader>
             <CardTitle className="text-center">Free Plan</CardTitle>
           </CardHeader>
@@ -21,7 +21,7 @@ export function Subscribe() {
             <p className="text-2xl font-bold">$0</p>
           </CardContent>
         </Card>
-        <Card className="shadow-lg bg-gradient-to-br from-yellow-400 via-yellow-500 to-yellow-600 text-white flex flex-col">
+        <Card className="shadow-lg bg-gradient-to-br from-blue-500 via-purple-500 to-purple-700 text-white flex flex-col h-96">
           <CardHeader>
             <CardTitle className="text-center">Plus Plan</CardTitle>
           </CardHeader>
@@ -29,7 +29,7 @@ export function Subscribe() {
             <p className="flex-1">Access to AI Assistant chat and future premium updates.</p>
             <Button
               size="sm"
-              className="bg-white text-yellow-700 hover:bg-gray-100"
+              className="bg-white text-purple-700 hover:bg-gray-100"
               onClick={() => upgradeToPlus()}
             >
               Subscribe for $9.99/month


### PR DESCRIPTION
## Summary
- enlarge plan cards and give Plus plan a purple gradient
- hook Get Plus and upgrade buttons to checkout flow
- document Stripe backend and required environment variables

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ea4ad5d908333a798cbef4b84be0b