### PR TITLE
Use real Stripe test keys for subscription

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -5,7 +5,14 @@ This project includes a React frontend and a minimal Node.js backend that uses S
 ## Running the backend
 
 1. Install dependencies with `npm install`.
-2. Set the environment variables `STRIPE_SECRET_KEY` and `STRIPE_PRICE_ID`.
+2. The server uses Stripe test credentials by default:
+
+   ```bash
+   STRIPE_SECRET_KEY=sk_test_51RrpqPIyxj79XoSA3wvkOQpgbTUCjzmr8BYkkIP4LvezmnKIrSxo8vzsTPaEG4IRS9rFDqAGFeZkDGfTsuort6O800NX7i5ta8
+   STRIPE_PRICE_ID=price_1RrqmAIyxj79XoSAWERvedqI
+   ```
+
+   You can override these by setting `STRIPE_SECRET_KEY` and `STRIPE_PRICE_ID` in your environment.
 3. From the project root, start the server:
 
    ```bash

--- a/project/server/index.js
+++ b/project/server/index.js
@@ -1,5 +1,15 @@
 import http from 'http';
 
+// Load Stripe credentials from environment variables or fall back to provided
+// test keys. This ensures the server uses real Stripe data instead of mock
+// placeholders when creating checkout sessions.
+const STRIPE_SECRET_KEY =
+  process.env.STRIPE_SECRET_KEY ||
+  'sk_test_51RrpqPIyxj79XoSA3wvkOQpgbTUCjzmr8BYkkIP4LvezmnKIrSxo8vzsTPaEG4IRS9rFDqAGFeZkDGfTsuort6O800NX7i5ta8';
+const PRICE_ID =
+  process.env.STRIPE_PRICE_ID ||
+  'price_1RrqmAIyxj79XoSAWERvedqI';
+
 /**
  * Minimal HTTP server used by the frontend to initiate Stripe Checkout.
  * Expects the following environment variables:
@@ -8,8 +18,6 @@ import http from 'http';
  *  - CLIENT_URL: base URL of the frontend application
  */
 const PORT = process.env.PORT || 3000;
-const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
-const PRICE_ID = process.env.STRIPE_PRICE_ID;
 const CLIENT_URL = process.env.CLIENT_URL || 'http://localhost:5173';
 
 if (!STRIPE_SECRET_KEY || !PRICE_ID) {


### PR DESCRIPTION
## Summary
- default Stripe server to actual test keys instead of placeholders
- document Stripe test credentials and how to override

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ebdd89ca483338da3519564f07dea