### PR TITLE
Add pricing page and Get Plus button

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -1,4 +1,9 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom';
 import { Layout } from '@/components/layout/Layout';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { Toaster } from '@/components/ui/toaster';
@@ -7,6 +12,7 @@ import { Medications } from '@/pages/Medications';
 import { AddMedication } from '@/pages/AddMedication';
 import { Chat } from '@/pages/Chat';
 import { NotFound } from '@/pages/NotFound';
+import { Pricing } from '@/pages/Pricing';
 import { useAuthStore } from '@/stores/authStore';
 
 function App() {
@@ -34,6 +40,7 @@ function App() {
             <Route path="meds" element={<Medications />} />
             <Route path="meds/new" element={<AddMedication />} />
             <Route path="chat" element={<Chat />} />
+            <Route path="pricing" element={<Pricing />} />
           </Route>
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/project/src/components/layout/Navbar.tsx
+++ b/project/src/components/layout/Navbar.tsx
@@ -46,11 +46,17 @@ export function Navbar() {
                 AI Chat
               </Link>
             </nav>
+            <Button
+              asChild
+              className="bg-gradient-to-r from-purple-500 to-pink-500 text-white hover:from-purple-600 hover:to-pink-600"
+            >
+              <Link to="/pricing">Get Plus</Link>
+            </Button>
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   className="bg-gradient-to-r from-blue-500 to-purple-500 text-white hover:from-blue-600 hover:to-purple-600 hover:text-white"
                 >

--- a/project/src/pages/Pricing.tsx
+++ b/project/src/pages/Pricing.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card';
+import { Check } from 'lucide-react';
+
+export function Pricing() {
+  return (
+    <div className="max-w-5xl mx-auto py-12">
+      <h1 className="text-3xl font-bold text-center mb-8">Choose Your Plan</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Free</CardTitle>
+            <CardDescription>Basic features for personal use</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              <li className="flex items-center">
+                <Check className="h-4 w-4 text-green-500 mr-2" />
+                Track up to 5 medications
+              </li>
+              <li className="flex items-center">
+                <Check className="h-4 w-4 text-green-500 mr-2" />
+                Basic AI chat
+              </li>
+            </ul>
+          </CardContent>
+          <CardFooter>
+            <Button className="w-full" variant="outline" disabled>
+              Current Plan
+            </Button>
+          </CardFooter>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Plus</CardTitle>
+            <CardDescription>Advanced features for power users</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              <li className="flex items-center">
+                <Check className="h-4 w-4 text-green-500 mr-2" />
+                Unlimited medications
+              </li>
+              <li className="flex items-center">
+                <Check className="h-4 w-4 text-green-500 mr-2" />
+                Priority AI chat
+              </li>
+              <li className="flex items-center">
+                <Check className="h-4 w-4 text-green-500 mr-2" />
+                Early access to new features
+              </li>
+            </ul>
+          </CardContent>
+          <CardFooter>
+            <Button className="w-full bg-gradient-to-r from-purple-500 to-blue-500 text-white hover:from-purple-600 hover:to-blue-600">
+              Get Plus
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default Pricing;


### PR DESCRIPTION
## Summary
- Add pricing page comparing Free and Plus plans
- Update navbar with Get Plus button
- Register pricing route in app router

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 12 problems)

------
https://chatgpt.com/codex/tasks/task_e_688ecf1350b48333933819ba07126163