### PR TITLE
Add subscription flow with subscribe form

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -13,6 +13,7 @@ import { AddMedication } from '@/pages/AddMedication';
 import { Chat } from '@/pages/Chat';
 import { NotFound } from '@/pages/NotFound';
 import { Pricing } from '@/pages/Pricing';
+import { Subscribe } from '@/pages/Subscribe';
 import { useAuthStore } from '@/stores/authStore';
 
 function App() {
@@ -41,6 +42,7 @@ function App() {
             <Route path="meds/new" element={<AddMedication />} />
             <Route path="chat" element={<Chat />} />
             <Route path="pricing" element={<Pricing />} />
+            <Route path="subscribe" element={<Subscribe />} />
           </Route>
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/project/src/pages/Pricing.tsx
+++ b/project/src/pages/Pricing.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
 import {
   Card,
   CardHeader,
@@ -59,8 +60,11 @@ export function Pricing() {
             </ul>
           </CardContent>
           <CardFooter>
-            <Button className="w-full bg-gradient-to-r from-purple-500 to-blue-500 text-white hover:from-purple-600 hover:to-blue-600">
-              Get Plus
+            <Button
+              asChild
+              className="w-full bg-gradient-to-r from-purple-500 to-blue-500 text-white hover:from-purple-600 hover:to-blue-600"
+            >
+              <Link to="/subscribe">Get Plus</Link>
             </Button>
           </CardFooter>
         </Card>

--- a/project/src/pages/Subscribe.tsx
+++ b/project/src/pages/Subscribe.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+
+export function Subscribe() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [payment, setPayment] = useState('');
+  const { toast } = useToast();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !email || !payment) {
+      toast({
+        title: 'Missing Information',
+        description: 'Please fill in all fields',
+        variant: 'destructive',
+      });
+      return;
+    }
+    toast({
+      title: 'Subscription Requested',
+      description: 'Your request has been submitted.',
+    });
+  };
+
+  return (
+    <div className="max-w-md mx-auto py-12">
+      <Card>
+        <CardHeader>
+          <CardTitle>Subscribe to Plus</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="name">Full Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="payment">Payment Details</Label>
+              <Input
+                id="payment"
+                value={payment}
+                onChange={(e) => setPayment(e.target.value)}
+                placeholder="Card Number"
+                required
+              />
+            </div>
+            <Button
+              type="submit"
+              className="w-full bg-gradient-to-r from-purple-500 to-blue-500 text-white hover:from-purple-600 hover:to-blue-600"
+            >
+              Subscribe
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default Subscribe;
+


### PR DESCRIPTION
## Summary
- add subscribe page with a form to collect user details for Plus
- link Get Plus button to the new subscribe page
- wire new subscribe route into app router

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in Login and authStore)
- `npm run build` (fails: Object literal may only specify known properties, 'photoURL')


------
https://chatgpt.com/codex/tasks/task_e_688ed12fbecc833399082e41bf030db1